### PR TITLE
Fix inconsistency and make subclasses with different events type compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,35 @@ Library adds no overhead. All it does is it simply reexports renamed `EventEmitt
 with customized typings.
 You can check **lib/index.js** to see the exported code.
 
+## Compatible subclasses with different events
+
+The type of `eventNames()` is a superset of the actual event names to make
+subclasses of a `TypedEmitter` that introduce different events type
+compatible. For example the following is possible:
+
+```
+class Animal<E extends ListenerSignature<E>=ListenerSignature<unknown>> extends TypedEmitter<{spawn: () => void} & E> {
+  constructor() {
+    super();
+  }
+}
+
+class Frog<E extends ListenerSignature<E>> extends Animal<{jump: () => void} & E> {
+}
+
+class Bird<E extends ListenerSignature<E>> extends Animal<{fly: () => void} & E> {
+}
+
+const animals: Animal[] = [new Frog(), new Bird()];
+```
+
+If the type of `eventNames()` was restricted to the actual event names,
+TypeScript would yield the following error for the last assignment:
+
+```
+Type 'Frog<{ spawn: any; }>' is not assignable to type 'Animal<ListenerSignature<unknown>>'.
+  The types returned by 'eventNames()' are incompatible between these types.
+    Type '("spawn" | "jump")[]' is not assignable to type '"spawn"[]'.
+      Type '"spawn" | "jump"' is not assignable to type '"spawn"'.
+        Type '"jump"' is not assignable to type '"spawn"'.
+```

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -12,7 +12,7 @@ export class TypedEmitter<L extends ListenerSignature<L> = DefaultListener> {
     prependListener<U extends keyof L>(event: U, listener: L[U]): this;
     prependOnceListener<U extends keyof L>(event: U, listener: L[U]): this;
     removeListener<U extends keyof L>(event: U, listener: L[U]): this;
-    removeAllListeners(event: keyof L): this;
+    removeAllListeners(event?: keyof L): this;
     once<U extends keyof L>(event: U, listener: L[U]): this;
     on<U extends keyof L>(event: U, listener: L[U]): this;
     off<U extends keyof L>(event: U, listener: L[U]): this;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -17,7 +17,7 @@ export class TypedEmitter<L extends ListenerSignature<L> = DefaultListener> {
     on<U extends keyof L>(event: U, listener: L[U]): this;
     off<U extends keyof L>(event: U, listener: L[U]): this;
     emit<U extends keyof L>(event: U, ...args: Parameters<L[U]>): boolean;
-    eventNames(): (keyof L)[];
+    eventNames<U extends keyof L>(): U[];
     listenerCount(type: keyof L): number;
     listeners<U extends keyof L>(type: U): L[U][];
     rawListeners<U extends keyof L>(type: U): L[U][];


### PR DESCRIPTION
Hi, thank you so much for your library, it's a blast to use.

The first commit fixes an inconsistency with the actual EventEmitter.

The second commit makes this library usable in scenarios where you must have compatible subclasses (which I think isn't uncommon).

Cheers!