### PR TITLE
Add constructor with optional parameter

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -8,6 +8,7 @@ export type DefaultListener = {
 
 export class TypedEmitter<L extends ListenerSignature<L> = DefaultListener> {
     static defaultMaxListeners: number;
+    constructor(options?: unknown);
     addListener<U extends keyof L>(event: U, listener: L[U]): this;
     prependListener<U extends keyof L>(event: U, listener: L[U]): this;
     prependOnceListener<U extends keyof L>(event: U, listener: L[U]): this;


### PR DESCRIPTION
Add a constructor to be able to pass optional parameters to the EventEmitter constructor (f.e. `{ captureRejections: true }`)

The argument could be typed too but then you need to update the interface for every new parameter added that i'm not sure is the best option.